### PR TITLE
refactor: optimize .gitignore for Markdown-based skill v1.3.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,48 @@
+# ============================================================
+# .gitignore - Michi Project (Markdown-based Claude Code Skill)
+# Version: v1.3.0+ optimized
+# Last Updated: 2026-01-16
+# ============================================================
+
+# ============================================================
 # Backup Files
-# Exclude backup files created by ai-agent-setup scripts
-*.backup.*  # AI設定スクリプト生成バックアップ（ダブルエクステンション）
+# ============================================================
+# AI設定スクリプト生成バックアップ（ダブルエクステンション）
+*.backup.*
 *.bak
 *~
 .#*
 #*#
 .michi-backup-*  # Michi バックアップディレクトリ
 
-# Dependencies
-node_modules/
-.pnp
-.pnp.js
-
+# ============================================================
 # Environment Variables
+# ============================================================
 .env
 .env.local
 .env.*.local
+.env.*.production  # 本番環境変数を明示的に除外
 
-# Build Outputs
-dist/
-build/
-*.tsbuildinfo
-*.tgz  # npm pack で生成されるビルド成果物
+# ============================================================
+# Credentials & Secrets
+# ============================================================
+*.key
+*.pem
+credentials.json
+secrets.json
+auth.json
+token.json
 
+# ============================================================
+# SSH Keys
+# ============================================================
+id_rsa*
+id_ed25519*
+*.ppk
+
+# ============================================================
 # Logs
+# ============================================================
 logs/
 *.log
 npm-debug.log*
@@ -31,13 +50,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-# Testing
-coverage/
-.nyc_output/
-.vitest/
-*.lcov
-
+# ============================================================
 # IDE
+# ============================================================
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
@@ -46,32 +61,39 @@ coverage/
 .idea/
 *.swp
 *.swo
-*~
 
+# ============================================================
 # OS
+# ============================================================
 .DS_Store
+._*  # macOS拡張属性ファイル
 Thumbs.db
 Desktop.ini
 
+# ============================================================
 # Temporary Files
+# ============================================================
 tmp/
 temp/
 *.tmp
 docs/tmp/
+*.md~  # Markdownエディタのバックアップ
+.~*.md  # Markdownエディタのロックファイル
 
-# Package Manager
-# package-lock.json  # OSSプロジェクトではリポジトリに含める（npm ciに必要）
-yarn.lock
-pnpm-lock.yaml
-
+# ============================================================
 # MCP Credentials (local only - use template for sharing)
+# ============================================================
 ~/.cursor/mcp.json
 
+# ============================================================
 # IDE-specific configurations
+# ============================================================
 .claude/
 .cursor/
 
+# ============================================================
 # Michi project settings (user/machine-specific configuration)
+# ============================================================
 # Contains config.json with user credentials, project-specific settings
 # Excludes: pj/, archive-pj/, multi-repo/ (user-specific data)
 # Includes in Git: settings/ (rules and templates shared across team)
@@ -79,12 +101,12 @@ pnpm-lock.yaml
 .michi/archive-pj/
 .michi/multi-repo/
 
+# ============================================================
 # AI Context
+# ============================================================
 AGENTS.mdecho
-*.backup  # 一般的なバックアップファイル（ドキュメント編集時などに生成）
 
+# ============================================================
 # Development and test scripts
+# ============================================================
 test-confluence-auth.js
-
-# Backup files
-*.backup.*

--- a/.gitignore
+++ b/.gitignore
@@ -81,13 +81,9 @@ docs/tmp/
 .~*.md  # Markdownエディタのロックファイル
 
 # ============================================================
-# MCP Credentials (local only - use template for sharing)
-# ============================================================
-~/.cursor/mcp.json
-
-# ============================================================
 # IDE-specific configurations
 # ============================================================
+# Note: MCP credentials are typically stored at ~/.cursor/mcp.json (outside repo)
 .claude/
 .cursor/
 


### PR DESCRIPTION
## Summary
- Markdownベースのスキル（v1.3.0+）に最適化した.gitignoreに改善
- TypeScript/ビルド関連のセクションを削除（不要になったため）
- セキュリティ強化項目を追加（認証情報、SSH鍵、macOS拡張属性）
- 重複エントリを整理し、セクション構成を改善

## 変更内容

### 削除したセクション（18行）
- Dependencies（node_modules/, .pnp, .pnp.js）
- Build Outputs（dist/, build/, *.tsbuildinfo, *.tgz）
- Testing（coverage/, .nyc_output/, .vitest/, *.lcov）
- Package Manager（package-lock.json, yarn.lock, pnpm-lock.yaml）

### 追加したセキュリティ項目
- 認証情報: *.key, *.pem, credentials.json, secrets.json, auth.json, token.json
- SSH鍵: id_rsa*, id_ed25519*, *.ppk
- macOS拡張属性: ._*
- Markdownエディタ一時ファイル: *.md~, .~*.md
- 環境変数: .env.*.production

### 整理した重複エントリ
- *~ をBackup Filesセクションに統一
- *.backup.* をBackup Filesセクションに統一

## Test plan
- [ ] .gitignoreが正しく機能することを確認
- [ ] 既存のGit管理下ファイルに影響がないことを確認
- [ ] セキュリティ項目が正しく除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 機密ファイル（環境変数、認証情報、SSH鍵など）の除外パターンを拡張・再編成しました。
  * 一時ファイルやMarkdown編集中のバックアップ、macOS/IDE固有のアーティファクト除外ルールを強化しました。
  * パッケージマネージャー関連やビルド/テスト出力の除外設定を見直し、整理しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->